### PR TITLE
Add OpenCode issue automation workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/opencode-request.yml
+++ b/.github/ISSUE_TEMPLATE/opencode-request.yml
@@ -1,0 +1,52 @@
+name: OpenCode request
+description: Ask OpenCode to derive requirements, break work down, and prepare an implementation lane.
+title: "[opencode] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- opencode:plan -->
+        Use this template when you want OpenCode to turn an issue into a concrete plan.
+
+        What happens next:
+        1. Planning runs automatically and comments with requirements, assumptions, and a task breakdown.
+        2. A maintainer can start implementation later by adding the `opencode:implement` label or commenting `/oc implement`.
+        3. Draft PRs created from this flow are reviewed automatically when they open or update.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What outcome do you want?
+      placeholder: Add a GitHub Actions workflow that...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Current context
+      description: What is the current behavior or limitation?
+      placeholder: Today the repository can..., but it cannot...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List the checks that make this issue done.
+      placeholder: |
+        - A new workflow exists for...
+        - The README explains...
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Technical, operational, or process constraints OpenCode must respect.
+      placeholder: Do not touch existing update workflows unless necessary.
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What should explicitly not be included?
+      placeholder: Do not add scheduled automation or auto-merge.

--- a/.github/workflows/opencode-implement.yaml
+++ b/.github/workflows/opencode-implement.yaml
@@ -1,0 +1,151 @@
+name: OpenCode Implement
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: write
+
+jobs:
+  implement:
+    if: |
+      (
+        github.event_name == 'issues' &&
+        github.event.issue.pull_request == null &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'opencode:implement' &&
+        github.event.sender.type != 'Bot'
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request == null &&
+        contains(github.event.comment.body, '/oc implement') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        ) &&
+        github.event.sender.type != 'Bot'
+      )
+    concurrency:
+      group: opencode-implement-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check for existing OpenCode PR
+        id: preflight
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          prefix="opencode/issue-${ISSUE_NUMBER}-"
+          mapfile -t existing_prs < <(gh pr list --state open --json number,headRefName,url --jq ".[] | select(.headRefName | startswith(\"${prefix}\")) | [.number, .url] | @tsv")
+          count=${#existing_prs[@]}
+
+          if [ "$count" -gt 1 ]; then
+            echo "More than one open OpenCode PR already exists for issue ${ISSUE_NUMBER}." >&2
+            printf '%s\n' "${existing_prs[@]}" >&2
+            exit 1
+          fi
+
+          if [ "$count" -eq 1 ]; then
+            pr_number="${existing_prs[0]%%$'\t'*}"
+            pr_url="${existing_prs[0]#*$'\t'}"
+            echo "existing_pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+            echo "existing_pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run OpenCode implementer
+        id: run_opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          # Webhook-triggered runs can use github.token.
+          # Set GH_TOKEN to a PAT only for manual gh workflow dispatches or API calls that need broader scopes.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        with:
+          model: cerebras/zai-glm-4.7
+          agent: opencode-implement
+          prompt: Implement the current GitHub issue in this repository and create or update the single draft PR for it.
+          use_github_token: true
+
+      - name: Resolve implementation PR
+        if: success()
+        id: resolve_pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          prefix="opencode/issue-${ISSUE_NUMBER}-"
+          # Intentional defensive wait for GitHub API eventual consistency.
+          # Newly created PRs can take several seconds to become queryable due to search/index propagation.
+          # This is not a race condition in our branch naming logic.
+          for attempt in 1 2 3 4 5; do
+            mapfile -t matching_prs < <(gh pr list --state open --json number,headRefName,url --jq ".[] | select(.headRefName | startswith(\"${prefix}\")) | [.number, .url] | @tsv")
+            count=${#matching_prs[@]}
+
+            if [ "$count" -eq 1 ]; then
+              pr_number="${matching_prs[0]%%$'\t'*}"
+              pr_url="${matching_prs[0]#*$'\t'}"
+              echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+              echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            if [ "$count" -gt 1 ]; then
+              echo "Multiple OpenCode PRs matched issue ${ISSUE_NUMBER}." >&2
+              printf '%s\n' "${matching_prs[@]}" >&2
+              exit 1
+            fi
+
+            sleep 5
+          done
+
+          echo "No OpenCode PR was found for issue ${ISSUE_NUMBER} after implementation completed." >&2
+          exit 1
+
+      - name: Dispatch OpenCode review
+        if: success() && steps.resolve_pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh workflow run opencode-review.yaml -f pr_number="$PR_NUMBER"
+
+      - name: Summarize diagnostics
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo '## OpenCode implementer'
+            echo
+            echo "- run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment failure back to the issue
+        if: failure() || cancelled()
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          number="$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")"
+          body=$'OpenCode implementation did not complete successfully.\n\n'
+          body+=$"Run: ${RUN_URL}"
+          gh api "repos/${{ github.repository }}/issues/${number}/comments" -f body="$body" >/dev/null

--- a/.github/workflows/opencode-plan.yaml
+++ b/.github/workflows/opencode-plan.yaml
@@ -1,0 +1,92 @@
+name: OpenCode Plan
+
+on:
+  issues:
+    types: [opened, reopened, labeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  plan:
+    if: |
+      (
+        github.event_name == 'issues' &&
+        github.event.issue.pull_request == null &&
+        (github.event.action == 'opened' || github.event.action == 'reopened') &&
+        contains(github.event.issue.body, '<!-- opencode:plan -->') &&
+        (
+          github.event.issue.author_association == 'OWNER' ||
+          github.event.issue.author_association == 'MEMBER' ||
+          github.event.issue.author_association == 'COLLABORATOR'
+        ) &&
+        github.event.sender.type != 'Bot'
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        github.event.issue.pull_request == null &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'opencode:plan' &&
+        github.event.sender.type != 'Bot'
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request == null &&
+        contains(github.event.comment.body, '/oc plan') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        ) &&
+        github.event.sender.type != 'Bot'
+      )
+    concurrency:
+      group: opencode-plan-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run OpenCode planner
+        id: run_opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          # Webhook-triggered runs can use github.token.
+          # Set GH_TOKEN to a PAT only for manual gh workflow dispatches or GitHub API calls that need broader scopes.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        with:
+          model: cerebras/zai-glm-4.7
+          agent: opencode-plan
+          prompt: Plan the current GitHub issue for this repository and publish the planning result on the issue.
+          use_github_token: true
+
+      - name: Summarize diagnostics
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo '## OpenCode planner'
+            echo
+            echo "- run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment failure back to the issue
+        if: failure() || cancelled()
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          number="$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")"
+          body=$'OpenCode planning did not complete successfully.\n\n'
+          body+=$"Run: ${RUN_URL}"
+          gh api "repos/${{ github.repository }}/issues/${number}/comments" -f body="$body" >/dev/null

--- a/.github/workflows/opencode-review.yaml
+++ b/.github/workflows/opencode-review.yaml
@@ -1,0 +1,484 @@
+name: OpenCode Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review.
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: read
+
+jobs:
+  review:
+    # workflow_dispatch is an explicit manual path, so it takes a PR number input
+    # instead of parsing /oc review commands from comment events.
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        startsWith(github.event.pull_request.head.ref, 'opencode/issue-')
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.pr_number != ''
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '/oc review') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        ) &&
+        github.event.sender.type != 'Bot'
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        (
+          contains(github.event.comment.body, '/oc review') ||
+          github.event.comment.in_reply_to_id != null
+        ) &&
+        github.event.sender.type != 'Bot'
+      )
+    concurrency:
+      group: opencode-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve pull request number
+        id: resolve_pr
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pr_number=''
+          case "${{ github.event_name }}" in
+            pull_request)
+              pr_number='${{ github.event.pull_request.number }}'
+              ;;
+            issue_comment)
+              pr_number='${{ github.event.issue.number }}'
+              ;;
+            pull_request_review_comment)
+              pr_number='${{ github.event.pull_request.number }}'
+              ;;
+            workflow_dispatch)
+              pr_number='${{ github.event.inputs.pr_number }}'
+              ;;
+          esac
+
+          if [ -z "$pr_number" ]; then
+            echo 'Unable to resolve pull request number for review.' >&2
+            exit 1
+          fi
+
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pull request merge ref
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: refs/pull/${{ steps.resolve_pr.outputs.pr_number }}/merge
+
+      - name: Preflight context guard
+        id: preflight
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+
+          pr_number='${{ steps.resolve_pr.outputs.pr_number }}'
+
+          mapfile -t changed_files < <(gh api --paginate "repos/${{ github.repository }}/pulls/${pr_number}/files?per_page=100" --jq '.[].filename')
+          file_count=${#changed_files[@]}
+          tmp_count=0
+
+          if [ "$file_count" -gt 0 ]; then
+            tmp_count=$(printf '%s\n' "${changed_files[@]}" | grep -c '^\.opencode-tmp/' || true)
+          fi
+
+          if [ "$tmp_count" -gt 0 ]; then
+            echo 'skip_opencode=true' >> "$GITHUB_OUTPUT"
+            echo 'skip_reason=detected .opencode-tmp/** files in PR diff' >> "$GITHUB_OUTPUT"
+          elif [ "$file_count" -gt 250 ]; then
+            echo 'skip_opencode=true' >> "$GITHUB_OUTPUT"
+            echo "skip_reason=PR diff too large for reliable agent context (${file_count} files)" >> "$GITHUB_OUTPUT"
+          else
+            echo 'skip_opencode=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Record current bot comment baseline
+        if: steps.preflight.outputs.skip_opencode != 'true'
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          comment_id="$(gh api "repos/${{ github.repository }}/issues/${{ steps.resolve_pr.outputs.pr_number }}/comments?per_page=100" --jq '[.[] | select(.user.login == "github-actions[bot]") | .id] | max // 0')"
+          echo "comment_id=${comment_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect review-thread reply context
+        if: steps.preflight.outputs.skip_opencode != 'true'
+        id: thread_context
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request_review_comment" ]; then
+            echo 'mode=full_review' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          current_comment_json="$(gh api "repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}")"
+          parent_comment_id="$(printf '%s' "$current_comment_json" | jq -r '.in_reply_to_id // empty')"
+
+          if [ -z "$parent_comment_id" ]; then
+            if printf '%s' '${{ github.event.comment.body }}' | grep -q '/oc review'; then
+              echo 'mode=full_review' >> "$GITHUB_OUTPUT"
+            else
+              echo 'mode=skip' >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          parent_json="$(gh api "repos/${{ github.repository }}/pulls/comments/${parent_comment_id}" 2>/dev/null || true)"
+          if [ -z "$parent_json" ]; then
+            echo 'mode=skip' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          parent_body="$(printf '%s' "$parent_json" | jq -r '.body')"
+
+          if printf '%s' "$parent_body" | grep -q '^<!-- OPCODE_INLINE_REVIEW -->'; then
+            echo 'mode=thread_reply' >> "$GITHUB_OUTPUT"
+            echo "parent_comment_id=${parent_comment_id}" >> "$GITHUB_OUTPUT"
+          elif printf '%s' '${{ github.event.comment.body }}' | grep -q '/oc review'; then
+            echo 'mode=full_review' >> "$GITHUB_OUTPUT"
+          else
+            echo 'mode=skip' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build review prompt
+        if: steps.preflight.outputs.skip_opencode != 'true' && steps.thread_context.outputs.mode != 'skip'
+        id: prompt
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+          PARENT_COMMENT_ID: ${{ steps.thread_context.outputs.parent_comment_id }}
+          CURRENT_COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.thread_context.outputs.mode }}" = 'thread_reply' ]; then
+            parent_json="$(gh api "repos/${{ github.repository }}/pulls/comments/${PARENT_COMMENT_ID}")"
+            parent_body="$(printf '%s' "$parent_json" | jq -r '.body')"
+            {
+              echo 'text<<EOF'
+              echo 'Reply to the current pull request review thread.'
+              echo 'Return only the hidden OPCODE_THREAD_REPLY block described in the review agent instructions.'
+              echo 'Always include a short non-empty reply_body for the in-thread response.'
+              echo 'Do not claim the thread is already resolved inside reply_body; resolution is handled separately by the workflow when permissions allow it.'
+              echo 'Set resolve to true only if the user reply indicates the issue is fixed, accepted, or no longer actionable.'
+              echo
+              echo 'Parent inline review comment:'
+              printf '%s\n' "$parent_body"
+              echo
+              echo 'User reply:'
+              printf '%s\n' "$CURRENT_COMMENT_BODY"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'text<<EOF'
+              echo 'Review the current pull request for this repository. Put file-specific findings on changed lines into the hidden OPCODE_INLINE_REVIEW JSON block at the end of your comment, and use the visible PR comment body only for overall summary or findings that cannot be attached cleanly to a diff location.'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment preflight skip back to the PR
+        if: steps.preflight.outputs.skip_opencode == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+
+          number='${{ steps.resolve_pr.outputs.pr_number }}'
+
+          body=$'OpenCode review skipped to avoid low-signal output.\n\n'
+          body+=$"Reason: ${{ steps.preflight.outputs.skip_reason }}"
+          gh api "repos/${{ github.repository }}/issues/${number}/comments" -f body="$body" >/dev/null
+
+      - name: Run OpenCode reviewer
+        if: steps.preflight.outputs.skip_opencode != 'true' && steps.thread_context.outputs.mode != 'skip'
+        id: run_opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          # Webhook-triggered runs can use github.token.
+          # Set GH_TOKEN to a PAT only for manual gh workflow dispatches or API calls that need broader scopes.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        with:
+          model: cerebras/zai-glm-4.7
+          agent: opencode-review
+          prompt: ${{ steps.prompt.outputs.text }}
+          use_github_token: true
+
+      - name: Extract structured inline review findings
+        if: success() && steps.preflight.outputs.skip_opencode != 'true' && steps.thread_context.outputs.mode != 'thread_reply'
+        id: extract_inline
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+          BASELINE_COMMENT_ID: ${{ steps.baseline.outputs.comment_id }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          pr_number = os.environ['PR_NUMBER']
+          baseline = int(os.environ['BASELINE_COMMENT_ID'])
+          repo = '${{ github.repository }}'
+          output_path = Path(os.environ['RUNNER_TEMP']) / 'opencode-inline-review.json'
+
+          cmd = ['gh', 'api', f'repos/{repo}/issues/{pr_number}/comments?per_page=100']
+          comments = json.loads(subprocess.run(cmd, check=True, capture_output=True, text=True).stdout)
+          candidates = [c for c in comments if c['id'] > baseline and c['user']['login'] == 'github-actions[bot]']
+          candidates.sort(key=lambda c: c['id'], reverse=True)
+
+          payload = {'comments': []}
+          for comment in candidates:
+            body = comment.get('body', '')
+            start = body.find('<!-- OPCODE_INLINE_REVIEW')
+            end = body.find('-->', start)
+            if start == -1 or end == -1:
+              continue
+            raw = body[start: end]
+            raw = raw.split('\n', 1)[1].strip()
+            try:
+              payload = json.loads(raw)
+            except json.JSONDecodeError:
+              sanitized = re.sub(r'"line":\s*([0-9]+)"', r'"line": \1', raw)
+              payload = json.loads(sanitized)
+            break
+
+          output_path.write_text(json.dumps(payload), encoding='utf-8')
+          print(f'count={len(payload.get("comments", []))}')
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
+            fh.write(f'count={len(payload.get("comments", []))}\n')
+            fh.write(f'path={output_path}\n')
+          PY
+
+      - name: Extract thread reply action
+        if: success() && steps.thread_context.outputs.mode == 'thread_reply'
+        id: extract_thread_reply
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+          BASELINE_COMMENT_ID: ${{ steps.baseline.outputs.comment_id }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          from pathlib import Path
+
+          pr_number = os.environ['PR_NUMBER']
+          baseline = int(os.environ['BASELINE_COMMENT_ID'])
+          repo = '${{ github.repository }}'
+          output_path = Path(os.environ['RUNNER_TEMP']) / 'opencode-thread-reply.json'
+
+          comments = json.loads(subprocess.run(['gh', 'api', f'repos/{repo}/issues/{pr_number}/comments?per_page=100'], check=True, capture_output=True, text=True).stdout)
+          candidates = [c for c in comments if c['id'] > baseline and c['user']['login'] == 'github-actions[bot]']
+          candidates.sort(key=lambda c: c['id'], reverse=True)
+
+          payload = {'reply_body': '', 'resolve': False, 'comment_ids': []}
+          for comment in candidates:
+            body = comment.get('body', '')
+            start = body.find('<!-- OPCODE_THREAD_REPLY')
+            if start == -1:
+              continue
+
+            search_start = body.find('{', start)
+            if search_start == -1:
+              continue
+
+            decoder = json.JSONDecoder()
+            payload, _ = decoder.raw_decode(body[search_start:])
+            payload['comment_ids'] = [c['id'] for c in candidates if '<!-- OPCODE_THREAD_REPLY' in c.get('body', '')]
+            break
+
+          output_path.write_text(json.dumps(payload), encoding='utf-8')
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
+            fh.write(f'path={output_path}\n')
+          PY
+
+      - name: Delete helper thread-reply comments
+        if: success() && steps.thread_context.outputs.mode == 'thread_reply'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          THREAD_REPLY_JSON_PATH: ${{ steps.extract_thread_reply.outputs.path }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+
+          payload = json.loads(open(os.environ['THREAD_REPLY_JSON_PATH'], 'r', encoding='utf-8').read())
+          repo = '${{ github.repository }}'
+          for comment_id in payload.get('comment_ids', []):
+            subprocess.run(['gh', 'api', f'repos/{repo}/issues/comments/{comment_id}', '-X', 'DELETE'], check=True, capture_output=True, text=True)
+          PY
+
+      - name: Remove previous managed inline review comments
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | select(.user.login == "github-actions[bot]") | [.id, .body] | @tsv' | while IFS=$'\t' read -r comment_id body; do
+            if printf '%s' "$body" | grep -q '^<!-- OPCODE_INLINE_REVIEW -->'; then
+              gh api "repos/${{ github.repository }}/pulls/comments/${comment_id}" -X DELETE >/dev/null
+            fi
+          done
+
+      - name: Create inline review comments
+        if: success() && steps.extract_inline.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+          INLINE_JSON_PATH: ${{ steps.extract_inline.outputs.path }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+
+          repo = '${{ github.repository }}'
+          pr_number = os.environ['PR_NUMBER']
+          head_sha = json.loads(subprocess.run(['gh', 'pr', 'view', pr_number, '--json', 'headRefOid'], check=True, capture_output=True, text=True).stdout)['headRefOid']
+          payload = json.loads(open(os.environ['INLINE_JSON_PATH'], 'r', encoding='utf-8').read())
+
+          for item in payload.get('comments', []):
+            if not isinstance(item.get('path'), str) or item['path'].strip() == '' or item['path'].startswith('../') or '/..' in item['path']:
+              continue
+            try:
+              line = int(item['line'])
+            except (KeyError, TypeError, ValueError):
+              continue
+            body = '<!-- OPCODE_INLINE_REVIEW -->\n' + item['body']
+            subprocess.run([
+              'gh', 'api', f'repos/{repo}/pulls/{pr_number}/comments', '-X', 'POST',
+              '-f', f'body={body}',
+              '-f', f'commit_id={head_sha}',
+              '-f', f'path={item["path"]}',
+              '-F', f'line={line}',
+              '-f', 'side=RIGHT',
+            ], check=True, capture_output=True, text=True)
+          PY
+
+      - name: Reply in review thread
+        if: success() && steps.thread_context.outputs.mode == 'thread_reply'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+          PARENT_COMMENT_ID: ${{ steps.thread_context.outputs.parent_comment_id }}
+          THREAD_REPLY_JSON_PATH: ${{ steps.extract_thread_reply.outputs.path }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+
+          payload = json.loads(open(os.environ['THREAD_REPLY_JSON_PATH'], 'r', encoding='utf-8').read())
+          body = payload.get('reply_body', '').strip()
+          if not body:
+            raise SystemExit(0)
+
+          subprocess.run([
+            'gh', 'api', f'repos/${{ github.repository }}/pulls/{os.environ["PR_NUMBER"]}/comments/{os.environ["PARENT_COMMENT_ID"]}/replies',
+            '-X', 'POST', '-f', f'body={body}'
+          ], check=True, capture_output=True, text=True)
+          PY
+
+      - name: Resolve review thread when requested
+        if: success() && steps.thread_context.outputs.mode == 'thread_reply'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+          PARENT_COMMENT_ID: ${{ steps.thread_context.outputs.parent_comment_id }}
+          THREAD_REPLY_JSON_PATH: ${{ steps.extract_thread_reply.outputs.path }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo 'GH_TOKEN secret is not configured; skipping thread resolution.'
+            exit 0
+          fi
+
+          resolve_requested="$(python3 - <<'PY'
+          import json, os
+          payload = json.loads(open(os.environ['THREAD_REPLY_JSON_PATH'], 'r', encoding='utf-8').read())
+          print('true' if payload.get('resolve') else 'false')
+          PY
+          )"
+
+          if [ "$resolve_requested" != 'true' ]; then
+            exit 0
+          fi
+
+          thread_json="$(gh api graphql -f query='query($owner:String!, $repo:String!, $pr:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$pr) { reviewThreads(first:100) { nodes { id isResolved comments(first:20) { nodes { databaseId } } } } } } }' -F owner='${{ github.repository_owner }}' -F repo='${{ github.event.repository.name }}' -F pr='${{ steps.resolve_pr.outputs.pr_number }}')"
+
+          thread_id="$(printf '%s' "$thread_json" | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | select((.comments.nodes | map(.databaseId) | index('"${PARENT_COMMENT_ID}"')) != null and (.isResolved | not)) | .id' | head -n 1)"
+
+          if [ -z "$thread_id" ] || [ "$thread_id" = 'null' ]; then
+            exit 0
+          fi
+
+          if ! gh api graphql -f query='mutation($threadId:ID!){ resolveReviewThread(input:{threadId:$threadId}) { thread { isResolved } } }' -F threadId="$thread_id" >/dev/null; then
+            echo 'Unable to resolve the review thread with the current GH_TOKEN permissions; leaving the thread open.'
+          fi
+
+      - name: Summarize diagnostics
+        if: always() && steps.preflight.outputs.skip_opencode != 'true'
+        shell: bash
+        run: |
+          {
+            echo '## OpenCode reviewer'
+            echo
+            echo "- run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment failure back to the PR
+        if: (failure() || cancelled()) && steps.preflight.outputs.skip_opencode != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          number='${{ steps.resolve_pr.outputs.pr_number }}'
+
+          body=$'OpenCode review did not complete successfully.\n\n'
+          body+=$"Run: ${RUN_URL}"
+          gh api "repos/${{ github.repository }}/issues/${number}/comments" -f body="$body" >/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.opencode/node_modules/
+.opencode/bun.lock
+.opencode/bun.lockb
+.opencode/package-lock.json
+.opencode/.bun/

--- a/.opencode/agents/opencode-implement.md
+++ b/.opencode/agents/opencode-implement.md
@@ -1,0 +1,44 @@
+---
+description: Implements scoped GitHub issues in this repository and creates or updates one draft PR
+mode: primary
+temperature: 0.1
+---
+You are the implementation worker for this repository.
+
+Read `AGENTS.md` first.
+
+Before acting, read `.github/workflows/opencode-implement.yaml`. If the issue would change workflow behavior, also read each directly implicated workflow file before editing.
+
+When you need external references, prefer `grep_app` for code examples, `context7` for library and API documentation, `deepwiki` for repository-oriented docs on public repositories, and `websearch` for broader web context. When plain text search is too noisy inside this repository, use `ast_grep_search` for structural matches.
+
+Your job is to implement the current GitHub Issue in this repository and create or update one draft PR.
+
+Requirements:
+- Use the issue body and the latest planning comment if one exists.
+- Start by restating the smallest implementation scope that satisfies the issue and the files you expect to touch first.
+- Keep the write set minimal and repo-local.
+- Create exactly one draft PR for the issue.
+- Use a branch name starting with `opencode/issue-<number>-` and a short sanitized slug from the issue title.
+- If a draft or open PR already exists for the issue, continue that lane instead of creating a second PR.
+- Run the relevant validation for the files you changed and report it. If no executable validation exists for a touched file, perform and report an explicit readback or manual verification instead.
+- Do not claim completion until the reported validation or manual verification has actually happened for the changed files.
+- Use these PR body headings exactly:
+  - `Status:`
+  - `Requirements:`
+  - `Breakdown:`
+  - `Tests Run:`
+  - `Known Risks:`
+  - `Requested Review:`
+
+Hard rules:
+- Do not push to any repository other than this one.
+- Do not use `vars.APP_ID` or `secrets.APP_PRIVATE_KEY` for this lane.
+- Do not touch the existing external nixpkgs automation workflows unless the issue explicitly scopes them in.
+- Do not create more than one PR.
+- Do not self-approve, merge, or close the issue unless the issue explicitly asks for administrative cleanup.
+- Do not drift from the latest planning comment without first explaining the mismatch in the issue or PR context.
+
+Blocked behavior:
+- If the issue is ambiguous, too large for one PR, or requires widening scope outside the inferred write set, stop and leave an issue comment describing the exact blocker.
+- If you discover a pre-existing PR for the issue, reuse it and explain what you updated.
+- If a touched file has neither an executable validation path nor a clear readback or manual verification path, stop and call that out explicitly instead of hand-waving it.

--- a/.opencode/agents/opencode-plan.md
+++ b/.opencode/agents/opencode-plan.md
@@ -1,0 +1,43 @@
+---
+description: Plans GitHub issues for this repository without making code changes
+mode: primary
+temperature: 0.1
+permission:
+  edit: deny
+  bash: deny
+---
+You are the planning worker for this repository.
+
+Read `AGENTS.md` first.
+
+Before acting, read `.github/workflows/opencode-plan.yaml`. If the issue is about workflow behavior or would change an existing workflow, read each directly implicated workflow file before writing the plan.
+
+When you need external references, prefer `grep_app` for code examples, `context7` for library and API documentation, `deepwiki` for repository-oriented docs on public repositories, and `websearch` for broader web context. When plain text search is too noisy inside this repository, use `ast_grep_search` for structural matches.
+
+Your job is to turn the current GitHub Issue into an implementation-ready plan without changing code.
+
+Requirements:
+- Start by identifying the smallest credible implementation scope for one draft PR and the concrete validations that scope would require.
+- Work from the issue body, issue title, labels, and the current discussion.
+- If a previous OpenCode planning comment exists, update or supersede it instead of creating noisy duplicates when possible.
+- Produce a single issue comment with these headings exactly:
+  - `## Requirements`
+  - `## Assumptions / Open Questions`
+  - `## Suggested Breakdown`
+  - `## Proposed Write Set`
+  - `## Ready for Implementation`
+- Break work into small, concrete tasks that could be implemented in one draft PR.
+- Call out which files or directories are likely in scope, and prefer exact file paths when they are inferable.
+- For each proposed task, make the readback or validation expectation explicit enough that an implementer can verify completion without guessing.
+- Be explicit when the issue is ambiguous or under-specified.
+
+Hard rules:
+- Do not create a branch, commit, or PR.
+- Do not approve, merge, or label anything.
+- Keep all reasoning repo-local unless the issue explicitly asks to modify the existing nixpkgs-targeting workflows.
+- Do not use or mention repository secrets.
+
+Output expectations:
+- `## Ready for Implementation` must end with either `yes` or `no` on its own line.
+- If the issue is not ready, explain the blocker in `## Assumptions / Open Questions`.
+- If the issue is ready, the plan must still make the scope boundary, likely write set, and validation approach concrete enough that the implementation lane can stay narrow.

--- a/.opencode/agents/opencode-review.md
+++ b/.opencode/agents/opencode-review.md
@@ -1,0 +1,63 @@
+---
+description: Reviews pull requests for this repository and leaves non-blocking feedback only
+mode: primary
+temperature: 0.1
+permission:
+  edit: deny
+  bash: deny
+---
+You are the review worker for this repository.
+
+Read `AGENTS.md` first.
+
+Before acting, read `.github/workflows/opencode-review.yaml`. If the PR touches workflow behavior, also read each directly implicated workflow file before reviewing.
+
+When you need external references, prefer `grep_app` for code examples, `context7` for library and API documentation, `deepwiki` for repository-oriented docs on public repositories, and `websearch` for broader web context. When plain text search is too noisy inside this repository, use `ast_grep_search` for structural matches.
+
+Your job is to review the current pull request and leave review feedback.
+
+Requirements:
+- Review the changed files, the PR description, and any available CI signal.
+- Treat PR claims as unproven until they are supported by the diff, reported validations, or other visible PR context.
+- Prefer a single concise review that focuses on correctness, missing validation, risky assumptions, and scope drift.
+- For file-specific findings on changed lines, use GitHub inline review comments anchored to the relevant diff location.
+- Do not place file-specific findings only in a top-level PR comment when they can be attached inline.
+- Reserve a top-level PR comment for overall summary, residual risk, or findings that cannot be attached cleanly to a diff location.
+- When you find a problem, prefer concrete findings that name the relevant file, section, or missing validation rather than generic concern.
+- Whether or not you find substantial problems, call out any residual risk or manual checks that still matter.
+- If there are no substantial problems, leave a comment saying the PR looks reasonable.
+- After the human-readable review text, append a hidden HTML block exactly in this format:
+
+  <!-- OPCODE_INLINE_REVIEW
+  {"comments":[{"path":"relative/path","line":123,"body":"inline comment text"}]}
+  -->
+
+- The JSON must be valid and single-object. Use `{"comments":[]}` when there are no inline findings.
+- Only include findings that belong on changed lines in the current PR diff. Use the line number from the current RIGHT side of the PR diff.
+- Every inline entry must use a repository file path and an integer `line` value.
+- Do not include PR-description, summary-only, or non-file findings inside the hidden JSON block.
+- If the prompt asks for `OPCODE_THREAD_REPLY`, output only a hidden block in exactly this format:
+
+  <!-- OPCODE_THREAD_REPLY
+  {"reply_body":"reply text","resolve":false}
+  -->
+
+- For `OPCODE_THREAD_REPLY`, `reply_body` should be the exact in-thread reply to post, and `resolve` should be `true` only when the user's reply indicates the thread should now be resolved.
+- For `OPCODE_THREAD_REPLY`, always provide a short non-empty `reply_body` unless there is a very strong reason not to reply at all.
+- For `OPCODE_THREAD_REPLY`, keep `reply_body` accurate even if the workflow cannot technically resolve the thread. Do not claim that the thread was already resolved inside `reply_body`.
+
+Hard rules:
+- Comment only.
+- Do not approve.
+- Do not request changes as a blocking review.
+- Do not push follow-up commits.
+- Do not merge the PR.
+
+Focus areas:
+- Does the PR match the linked issue and the apparent plan, or does it quietly widen scope?
+- Does the PR satisfy the linked issue?
+- Did it stay within a reasonable write set?
+- Are the validations reported believable for the changed files?
+- Does the PR description over-claim what was validated or completed?
+- Did it accidentally touch the existing nixpkgs-targeting workflows or credentials paths without clear need?
+- What residual risk or manual verification still remains even if the PR looks acceptable?

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@ast-grep/cli": "0.42.1",
+    "@opencode-ai/plugin": "1.3.17"
+  }
+}

--- a/.opencode/tools/ast_grep.js
+++ b/.opencode/tools/ast_grep.js
@@ -1,0 +1,111 @@
+import path from "node:path"
+
+import { tool } from "@opencode-ai/plugin"
+
+function indentBlock(text, spaces) {
+  const prefix = " ".repeat(spaces)
+  return text.split("\n").map((line) => `${prefix}${line}`).join("\n")
+}
+
+function buildInlineRule(language, pattern) {
+  return [
+    "id: ast-grep-inline-search",
+    `language: ${language}`,
+    "rule:",
+    "  pattern: |",
+    indentBlock(pattern, 4),
+  ].join("\n")
+}
+
+function formatMatch(match) {
+  return {
+    file: match.file,
+    line: (match.range?.start?.line ?? 0) + 1,
+    column: (match.range?.start?.column ?? 0) + 1,
+    language: match.language,
+    text: match.text,
+    lines: match.lines,
+    metaVariables: match.metaVariables,
+  }
+}
+
+export const search = tool({
+  description: "Search code structurally with ast-grep patterns.",
+  args: {
+    pattern: tool.schema.string().describe("AST pattern to search for."),
+    language: tool.schema.string().describe("ast-grep language name, for example yaml, javascript, or typescript."),
+    paths: tool.schema.array(tool.schema.string()).optional().describe("Paths to search. Defaults to the whole repository."),
+    globs: tool.schema.array(tool.schema.string()).optional().describe("Optional ast-grep globs to include or exclude paths."),
+    context: tool.schema.number().int().min(0).max(10).optional().describe("Context lines to include around each match."),
+    max_results: tool.schema.number().int().min(1).max(200).optional().describe("Maximum number of matches to return."),
+    include_hidden: tool.schema.boolean().optional().describe("Include hidden files and directories."),
+  },
+  async execute(args, context) {
+    const astGrepBinary = path.join(
+      context.worktree,
+      ".opencode",
+      "node_modules",
+      ".bin",
+      process.platform === "win32" ? "ast-grep.cmd" : "ast-grep",
+    )
+
+    const command = [
+      astGrepBinary,
+      "scan",
+      "--inline-rules",
+      buildInlineRule(args.language, args.pattern),
+      "--json=stream",
+    ]
+
+    if (typeof args.context === "number") {
+      command.push("--context", String(args.context))
+    }
+
+    if (typeof args.max_results === "number") {
+      command.push("--max-results", String(args.max_results))
+    }
+
+    if (args.include_hidden) {
+      command.push("--no-ignore", "hidden")
+    }
+
+    for (const glob of args.globs ?? []) {
+      command.push("--globs", glob)
+    }
+
+    command.push(...(args.paths?.length ? args.paths : [context.worktree]))
+
+    const proc = Bun.spawn(command, {
+      cwd: context.worktree,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    if (exitCode !== 0) {
+      throw new Error(stderr.trim() || `ast-grep exited with status ${exitCode}`)
+    }
+
+    const matches = stdout
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line))
+      .map(formatMatch)
+
+    return JSON.stringify(
+      {
+        pattern: args.pattern,
+        language: args.language,
+        matchCount: matches.length,
+        matches,
+      },
+      null,
+      2,
+    )
+  },
+})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# OpenCode workflow rules for this repository
+
+This repository primarily stores automation that maintains a fork of `wattmto/nixpkgs`.
+
+## Default scope
+
+- Unless an issue explicitly says otherwise, keep all OpenCode work inside this repository.
+- Treat the existing `merge-upstream.yaml`, `rebase-packages.yaml`, and `update-packages.yaml` workflows as production infrastructure. Do not change them unless the issue is specifically about them.
+
+## Hard boundaries
+
+- Do not push to `wattmto/nixpkgs` or any other external repository.
+- Do not use `vars.APP_ID` or `secrets.APP_PRIVATE_KEY` for OpenCode-driven issue planning, implementation, or review.
+- Do not modify secrets, repository settings, labels, or branch protection.
+- Do not create more than one PR for the same issue.
+
+## Planning lane
+
+- Planning requests are comment-only.
+- Convert the issue into explicit requirements, assumptions, a task breakdown, and a recommended implementation scope.
+- Do not create a branch, commit, or PR while planning.
+
+## Implementation lane
+
+- Implement from the issue body plus the latest planning comment when available.
+- Keep the write set minimal and repo-local.
+- Create exactly one draft PR.
+- Use a branch name that starts with `opencode/issue-<number>-`.
+- If a PR already exists for the issue, update that lane instead of creating another.
+
+## Review lane
+
+- Review PRs by leaving comments only.
+- Do not approve, request changes, merge, or push follow-up commits during review.
+
+## Validation expectations
+
+- Validate the files you change.
+- For workflow changes, prefer syntax validation plus a dry structural check: verify the workflow trigger, `if` guards, permission scopes, concurrency key, and referenced secrets or inputs still line up with the intended lane behavior.
+- For the dry structural check, explicitly confirm the workflow trigger matches the lane, the `if` conditions admit only intended events, the permissions are no broader than needed, the concurrency key isolates the lane, and every referenced secret or input matches the lane contract.
+- For shell changes, run `bash -n`.
+- Report the concrete commands you ran.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # nixpkgs-automation
+
+This repository stores GitHub Actions automation that maintains a fork of `wattmto/nixpkgs`.
+
+It also includes OpenCode-driven planning, implementation, and review workflows for repo-local automation work.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "openai": {
+      "options": {
+        "baseURL": "{env:OPENAI_BASE_URL}"
+      },
+      "models": {
+        "gpt-oss-120b": {
+          "name": "gpt-oss-120b"
+        },
+        "GLM-4.7-AWQ": {
+          "name": "GLM-4.7-AWQ"
+        }
+      }
+    }
+  },
+  "mcp": {
+    "grep_app": {
+      "type": "remote",
+      "url": "https://mcp.grep.app",
+      "enabled": true,
+      "timeout": 8000
+    },
+    "deepwiki": {
+      "type": "remote",
+      "url": "https://mcp.deepwiki.com/mcp",
+      "enabled": true,
+      "timeout": 8000
+    },
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "enabled": true,
+      "timeout": 8000
+    },
+    "websearch": {
+      "type": "remote",
+      "url": "https://mcp.exa.ai/mcp?tools=web_search_exa",
+      "enabled": true,
+      "timeout": 8000
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add gated OpenCode GitHub Actions workflows for issue planning, implementation, and PR review
- move durable lane behavior into repo-local OpenCode agents and document the operating model in `AGENTS.md` and `README.md`
- keep the automation repo-local and maintainer-controlled so it does not interfere with the existing nixpkgs update workflows

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` on the OpenCode workflow YAML files, issue template YAML, and `opencode.json`
- `python3 - <<'PY' ... frontmatter/read-rule checks ... PY` on `.opencode/agents/*.md`
- `node -c .opencode/tools/ast_grep.js`

## Notes
- branch name uses `issue-0` because this PR was created directly from chat rather than from a repository issue
- this PR is intentionally draft so the new workflow lane can be reviewed before use