### PR TITLE
Set lane-specific OpenCode default agents in workflows

### DIFF
--- a/.github/workflows/opencode-implement.yaml
+++ b/.github/workflows/opencode-implement.yaml
@@ -69,6 +69,14 @@ jobs:
             echo "existing_pr_url=$pr_url" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Select OpenCode implementer agent
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          jq '.default_agent = "opencode-implement"' opencode.json > "$tmp"
+          mv "$tmp" opencode.json
+
       - name: Run OpenCode implementer
         id: run_opencode
         uses: anomalyco/opencode/github@latest

--- a/.github/workflows/opencode-plan.yaml
+++ b/.github/workflows/opencode-plan.yaml
@@ -55,6 +55,14 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Select OpenCode planner agent
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          jq '.default_agent = "opencode-plan"' opencode.json > "$tmp"
+          mv "$tmp" opencode.json
+
       - name: Run OpenCode planner
         id: run_opencode
         uses: anomalyco/opencode/github@latest

--- a/.github/workflows/opencode-review.yaml
+++ b/.github/workflows/opencode-review.yaml
@@ -106,14 +106,19 @@ jobs:
           mapfile -t changed_files < <(gh api --paginate "repos/${{ github.repository }}/pulls/${pr_number}/files?per_page=100" --jq '.[].filename')
           file_count=${#changed_files[@]}
           tmp_count=0
+          opencode_workflow_count=0
 
           if [ "$file_count" -gt 0 ]; then
             tmp_count=$(printf '%s\n' "${changed_files[@]}" | grep -c '^\.opencode-tmp/' || true)
+            opencode_workflow_count=$(printf '%s\n' "${changed_files[@]}" | grep -c '^\.github/workflows/opencode-.*\.ya\?ml$' || true)
           fi
 
           if [ "$tmp_count" -gt 0 ]; then
             echo 'skip_opencode=true' >> "$GITHUB_OUTPUT"
             echo 'skip_reason=detected .opencode-tmp/** files in PR diff' >> "$GITHUB_OUTPUT"
+          elif [ "$opencode_workflow_count" -gt 0 ]; then
+            echo 'skip_opencode=true' >> "$GITHUB_OUTPUT"
+            echo 'skip_reason=detected OpenCode workflow files in PR diff' >> "$GITHUB_OUTPUT"
           elif [ "$file_count" -gt 250 ]; then
             echo 'skip_opencode=true' >> "$GITHUB_OUTPUT"
             echo "skip_reason=PR diff too large for reliable agent context (${file_count} files)" >> "$GITHUB_OUTPUT"
@@ -220,6 +225,15 @@ jobs:
           body=$'OpenCode review skipped to avoid low-signal output.\n\n'
           body+=$"Reason: ${{ steps.preflight.outputs.skip_reason }}"
           gh api "repos/${{ github.repository }}/issues/${number}/comments" -f body="$body" >/dev/null
+
+      - name: Select OpenCode reviewer agent
+        if: steps.preflight.outputs.skip_opencode != 'true' && steps.thread_context.outputs.mode != 'skip'
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          jq '.default_agent = "opencode-review"' opencode.json > "$tmp"
+          mv "$tmp" opencode.json
 
       - name: Run OpenCode reviewer
         if: steps.preflight.outputs.skip_opencode != 'true' && steps.thread_context.outputs.mode != 'skip'


### PR DESCRIPTION
Status:
- Draft
- Closes #19

Requirements:
- Make each OpenCode workflow select its intended local agent even while the upstream GitHub action falls back to `default_agent`
- Use a repo-local mitigation rather than timeout-based symptom handling
- Keep workflow triggers, permissions, concurrency, prompts, and secrets unchanged

Breakdown:
- Add a lane-specific selector step to `opencode-plan.yaml` that rewrites `opencode.json` with `default_agent = \"opencode-plan\"` before invoking OpenCode
- Add the same selector pattern to `opencode-implement.yaml` with `default_agent = \"opencode-implement\"`
- Add the same selector pattern to `opencode-review.yaml` with the same guard as the reviewer step and `default_agent = \"opencode-review\"`
- Use `jq` for the workspace rewrite so the action reads the intended agent from the checked-out config it already consults

Tests Run:
- `python3 -c "import yaml, pathlib; files=['.github/workflows/opencode-plan.yaml','.github/workflows/opencode-implement.yaml','.github/workflows/opencode-review.yaml']; [yaml.safe_load(pathlib.Path(f).read_text()) for f in files]; print('\\n'.join('OK ' + f for f in files))"`
- `bash -n /tmp/select-opencode-planner-agent.sh && bash -n /tmp/select-opencode-implementer-agent.sh && bash -n /tmp/select-opencode-reviewer-agent.sh`
- `jj diff --stat`

Known Risks:
- The workaround depends on the upstream action continuing to read the checked-out workspace copy of `opencode.json`
- Each workflow intentionally dirties the ephemeral runner workspace by rewriting `opencode.json` before the OpenCode step

Requested Review:
- Confirm the lane-local `default_agent` override is an acceptable repo-side mitigation until the upstream action starts honoring `with.agent`
- Confirm the review lane should keep sharing the same `if` guard between the selector step and the OpenCode reviewer step